### PR TITLE
fix array of enums to array

### DIFF
--- a/src/DTO/AbstractDTO.php
+++ b/src/DTO/AbstractDTO.php
@@ -136,6 +136,12 @@ class AbstractDTO implements \JsonSerializable
                 continue;
             }
 
+            if ($subitem instanceof \UnitEnum) {
+                $arr[$subKey] = $subitem->name;
+
+                continue;
+            }
+
             $arr[$subKey] = $subitem instanceof self ? $subitem->toArray() : $subitem;
         }
 


### PR DESCRIPTION
Když je v datech enum, tak převede na string (použije se name z enumu), ale když se v datech posílá array enumů, tak se enum převáděl na string tak, že se vzala value z enumu. Tímhle to sjednocuju